### PR TITLE
Update build and publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master # Default release branch
-      - pr/* # Pull requests
 jobs:
   publish:
     name: build, pack & publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,13 @@
-name: publish to nuget
+name: Build and Publish to NuGet
+
 on:
   push:
     branches:
-      - master # Default release branch
+      - '**' # Run on push to any branch
+
 jobs:
-  publish:
-    name: build, pack & publish
+  build:
+    name: Build the project
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,10 +20,37 @@ jobs:
       - name: Build the project
         run: dotnet build --configuration Release
 
-      # Publish
+      - name: Save build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build_artifacts
+          path: 'HP.CloudApi.Client/bin/Release/*.nupkg'
+
+  publish:
+    name: Publish to NuGet
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.ref_name == 'master' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build_artifacts
+          path: build_artifacts
+
+      - name: List artifact files
+        run: ls -R build_artifacts
+
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 7.0.x
+
       - name: Publish the package to nuget.org
         run: |
-          for file in */bin/Release/*.nupkg; do
+          for file in build_artifacts/*.nupkg; do
             dotnet nuget push "$file" -k $NUGET_AUTH_TOKEN -s https://api.nuget.org/v3/index.json --skip-duplicate
           done
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,10 +3,11 @@ on:
   push:
     branches:
       - master # Default release branch
+      - pr/* # Pull requests
 jobs:
   publish:
     name: build, pack & publish
-    runs-on: windows-2022
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -14,12 +15,15 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 7.0.x
-      
-      
-      - run: dotnet build --configuration Release
+
+      - name: Build the project
+        run: dotnet build --configuration Release
 
       # Publish
       - name: Publish the package to nuget.org
-        run: dotnet nuget push */bin/Release/*.nupkg -k $NUGET_AUTH_TOKEN -s https://api.nuget.org/v3/index.json
+        run: |
+          for file in */bin/Release/*.nupkg; do
+            dotnet nuget push "$file" -k $NUGET_AUTH_TOKEN -s https://api.nuget.org/v3/index.json
+          done
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Publish the package to nuget.org
         run: |
           for file in */bin/Release/*.nupkg; do
-            dotnet nuget push "$file" -k $NUGET_AUTH_TOKEN -s https://api.nuget.org/v3/index.json
+            dotnet nuget push "$file" -k $NUGET_AUTH_TOKEN -s https://api.nuget.org/v3/index.json --skip-duplicate
           done
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
* Run dotnet build on every branch
* Create artifacts -> nupkg
* Publish to Nuget on master branch pushes; skip if duplicated
* Change the build server to be ubuntu-latest instead of windows