### PR TITLE
Cleanup and change target framework

### DIFF
--- a/HP.CloudApi.Client/CloudApiClient.cs
+++ b/HP.CloudApi.Client/CloudApiClient.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using HeimdallPower.Entities;
 using HeimdallPower.Enums;

--- a/HP.CloudApi.Client/Entities/ApiResponse.cs
+++ b/HP.CloudApi.Client/Entities/ApiResponse.cs
@@ -1,7 +1,6 @@
-﻿using System.Collections.Generic;
-namespace HeimdallPower.Entities
+﻿namespace HeimdallPower.Entities
 {
-    public class ApiResponse<T> where T: class
+    public class ApiResponse<T> where T : class
     {
         public T Data;
         public string Message;

--- a/HP.CloudApi.Client/Entities/LineAggregatedDLRForecastDto.cs
+++ b/HP.CloudApi.Client/Entities/LineAggregatedDLRForecastDto.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace HeimdallPower.Entities
 {

--- a/HP.CloudApi.Client/Enums/MeasurementTypeTemp.cs
+++ b/HP.CloudApi.Client/Enums/MeasurementTypeTemp.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace HeimdallPower.Enums
+﻿namespace HeimdallPower.Enums
 {
     public class MeasurementType2
     {

--- a/HP.CloudApi.Client/HP.CloudApi.Client.csproj
+++ b/HP.CloudApi.Client/HP.CloudApi.Client.csproj
@@ -12,6 +12,7 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/heimdallpower/HP.CloudApi.Client</RepositoryUrl>
     <PackageProjectUrl>https://heimdallbrain.atlassian.net/wiki/spaces/HCUG/pages/1444347938/Heimdall+Cloud+API</PackageProjectUrl>
+	<RootNamespace>HeimdallPower</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/HP.CloudApi.Client/HP.CloudApi.Client.csproj
+++ b/HP.CloudApi.Client/HP.CloudApi.Client.csproj
@@ -8,7 +8,7 @@
     <PackageId>HeimdallPower.CloudApi.Client</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>A client for the Heimdall Cloud API</Description>
-    <Version>2.0.3</Version>
+    <Version>2.0.4</Version>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/heimdallpower/HP.CloudApi.Client</RepositoryUrl>
     <PackageProjectUrl>https://heimdallbrain.atlassian.net/wiki/spaces/HCUG/pages/1444347938/Heimdall+Cloud+API</PackageProjectUrl>

--- a/HP.CloudApi.Client/HP.CloudApi.Client.csproj
+++ b/HP.CloudApi.Client/HP.CloudApi.Client.csproj
@@ -24,7 +24,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="2.18.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/HP.CloudApi.Client/HP.CloudApi.Client.csproj
+++ b/HP.CloudApi.Client/HP.CloudApi.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <Company>Heimdall Power</Company>
     <Authors>Heimdall Power</Authors>

--- a/HP.CloudApi.Client/HP.CloudApi.Client.csproj
+++ b/HP.CloudApi.Client/HP.CloudApi.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>10</LangVersion>
     <Company>Heimdall Power</Company>
     <Authors>Heimdall Power</Authors>

--- a/HP.CloudApi.Client/HeimdallHttpClient.cs
+++ b/HP.CloudApi.Client/HeimdallHttpClient.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Newtonsoft.Json;
@@ -36,7 +34,7 @@ namespace HeimdallPower
         public HeimdallHttpClient(string clientId, string clientSecret, bool useDeveloperApi)
         {
             _scope = useDeveloperApi ? DevScope : ProdScope;
-            _instance = useDeveloperApi ? DevInstance: ProdInstance;
+            _instance = useDeveloperApi ? DevInstance : ProdInstance;
             _domain = useDeveloperApi ? DevDomain : ProdDomain;
             _authority = useDeveloperApi ? DevAuthority : ProdAuthority;
             var apiUrl = useDeveloperApi ? DevApiUrl : ProdApiUrl;

--- a/HP.CloudApi.Client/UrlBuilder.cs
+++ b/HP.CloudApi.Client/UrlBuilder.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using System.Threading.Tasks;
-using System.Web;
 using HeimdallPower.Entities;
 using HeimdallPower.Enums;
 using HeimdallPower.ExtensionMethods;
@@ -29,8 +24,8 @@ namespace HeimdallPower
             return new NameValueCollection()
                 .AddQueryParam("fromDateTime", from.ToString(DateFormat))
                 .AddQueryParam("toDateTime", to.ToString(DateFormat));
-        }        
-        
+        }
+
         private static NameValueCollection GetIdentifierParam(LineDto line, SpanDto span, SpanPhaseDto spanPhase)
         {
             var identifierParam = new NameValueCollection();
@@ -69,7 +64,7 @@ namespace HeimdallPower
             var queryParams = new NameValueCollection()
                 .AddQueryParam(GetDateTimeParams(from, to))
                 .AddQueryParam(GetIdentifierParam(line, span, spanPhase));
-            return GetFullUrl( IcingData, queryParams);
+            return GetFullUrl(IcingData, queryParams);
         }
 
         public static string BuildSagAndClearanceUrl(LineDto line, SpanDto span, SpanPhaseDto spanPhase, DateTime from, DateTime to)
@@ -88,8 +83,8 @@ namespace HeimdallPower
                 .AddQueryParam(GetIntervalDurationParam(intervalDuration))
                 .AddQueryParam("dlrType", dlrType.ToString());
             return GetFullUrl(AggregatedDLR, queryParams);
-        }        
-        
+        }
+
         public static string BuildAggregatedDlrForecastUrl(LineDto line, int hoursAhead)
         {
             var queryParams = new NameValueCollection()
@@ -97,7 +92,7 @@ namespace HeimdallPower
                 .AddQueryParam("hoursAhead", hoursAhead.ToString());
             return GetFullUrl(AggregatedDLRForecast, queryParams);
         }
-        
+
 
         private static string GetFullUrl(string endpoint, NameValueCollection queryParams, string apiVersion = V1)
         {


### PR DESCRIPTION
* Set root namespace: removing all the namespace warnings.
* Target net-standard  2.1; make the project compatible with dotnet 3.0, 3.1, 5.0, 6.0, 7.0, and 8.0 to facilitate library adoption.
* Removed unused usings in the project
* Removed unused dependency on Microsoft.CSharp